### PR TITLE
Fix report integrity, Python startup, and connectivity monitoring

### DIFF
--- a/.github/workflows/connectivity-probe.yml
+++ b/.github/workflows/connectivity-probe.yml
@@ -25,6 +25,7 @@ jobs:
         run: pip install "requests>=2.31.0"
 
       - name: 运行连通性探测
+        shell: bash
         run: python scripts/connectivity_probe.py | tee probe_output.txt
 
       - name: 异常时通知 repo owner（去重）

--- a/README.md
+++ b/README.md
@@ -65,3 +65,21 @@
 ## Credits
 
 爬虫逻辑基于 [gaodechen/cninfo_process](https://github.com/gaodechen/cninfo_process)。
+
+## 开发测试
+
+在独立环境中安装运行依赖和 pytest 后执行全部 Python 与 Node 回归测试：
+
+```bash
+python3 -m venv .venv
+# Windows: .venv\Scripts\activate
+source .venv/bin/activate
+python -m pip install -r python/requirements.txt pytest
+npm test
+```
+
+也可使用 uv 临时环境：
+
+```bash
+uv run --no-project --with pytest --with requests --with 'mcp~=2.1.1' npm test
+```

--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@
 
 爬虫逻辑基于 [gaodechen/cninfo_process](https://github.com/gaodechen/cninfo_process)。
 
+## 结果与错误
+
+股票代码必须为六位数字，可带首尾空白（如 `" 000001 "`）；无效输入在请求或创建目录前被拒绝。
+查询和下载结果包含 `status`：`complete` 表示完整完成（包括成功查询到零条），`partial` 表示部分完成，`error` 表示失败。只有 `complete` 的 `success` 为 `true`。
+查询中断时保留已取得的报告，并返回 `error` / `errors`；Python 的 `query_reports` 调用方可从 `QueryError.reports` 取得部分结果。
+下载返回 `downloaded`、`files`、`failed`、`failures`，另有 `query_status` 和查询失败时的 `query_errors`。单个附件失败后继续处理其余附件。
+文件名包含附件 URL 的稳定 SHA-256 标识；下载经 PDF 签名与响应类型检查后，使用临时文件原子替换。
+附件链接统一解析为 `https://static.cninfo.com.cn` 地址；下载最多跟随五次重定向，每一跳都校验协议、主机和端口。无效链接在查询结果中显示为空并附带 `attachmentError`，下载时作为单个附件失败返回。
+
 ## 开发测试
 
 在独立环境中安装运行依赖和 pytest 后执行全部 Python 与 Node 回归测试：

--- a/bin/cninfo-mcp.js
+++ b/bin/cninfo-mcp.js
@@ -20,7 +20,7 @@ const PYTHON_REQUIREMENTS = path.join(
 );
 
 // 虚拟环境目录，放在用户目录下保证跨 npx 调用持久化
-const VENV_DIR = path.join(os.homedir(), ".cninfo-mcp", "venv");
+let VENV_DIR = path.join(os.homedir(), ".cninfo-mcp", "venv");
 
 // 获取虚拟环境中的 Python 可执行文件路径
 function getVenvPython() {
@@ -31,6 +31,26 @@ function getVenvPython() {
 }
 
 // 查找可用的系统 Python 可执行文件（仅用于创建 venv）
+async function isSupportedPython(cmd) {
+  try {
+    const result = await spawnAsync(cmd, ["--version"]);
+    const version = `${result.stdout || ""} ${result.stderr || ""}`.match(/\bPython (\d+)\.(\d+)\.(\d+)\b/);
+    return Boolean(version && Number(version[1]) === 3 && Number(version[2]) >= 10);
+  } catch {
+    return false;
+  }
+}
+
+// Preserve an obsolete environment and create a compatible sibling if needed.
+async function reusableVenv() {
+  if (!fs.existsSync(getVenvPython())) return null;
+  if (await isSupportedPython(getVenvPython())) return getVenvPython();
+  VENV_DIR += "-py310";
+  if (!fs.existsSync(getVenvPython())) return null;
+  if (await isSupportedPython(getVenvPython())) return getVenvPython();
+  throw new Error(`Unsupported or broken Python environment at ${VENV_DIR}. Recreate it with Python 3.10+.`);
+}
+
 async function findPython() {
   const pythonCommands = [
     "python3",
@@ -41,14 +61,7 @@ async function findPython() {
   ];
 
   for (const cmd of pythonCommands) {
-    try {
-      const result = await spawnAsync(cmd, ["--version"]);
-      if (result.stdout && result.stdout.includes("Python")) {
-        return cmd;
-      }
-    } catch (error) {
-      // 继续尝试下一个命令
-    }
+    if (await isSupportedPython(cmd)) return cmd;
   }
 
   throw new Error(
@@ -67,7 +80,7 @@ async function ensureVenv(systemPythonCmd) {
   console.error("Creating Python virtual environment...");
   fs.mkdirSync(path.dirname(VENV_DIR), { recursive: true });
   await spawnAsync(systemPythonCmd, ["-m", "venv", VENV_DIR], {
-    stdio: "inherit",
+    stdio: ["ignore", 2, 2],
   });
   console.error("Virtual environment created\n");
   return venvPython;
@@ -96,7 +109,7 @@ async function ensureDependencies(venvPython) {
         venvPython,
         ["-m", "pip", "install", "-r", requirementsPath],
         {
-          stdio: "inherit",
+          stdio: ["ignore", 2, 2],
         },
       );
       console.error("Python dependencies installed successfully\n");
@@ -114,7 +127,7 @@ function spawnAsync(command, args, options = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       stdio: options.stdio || "pipe",
-      shell: process.platform === "win32",
+      shell: false,
       ...options,
     });
 
@@ -161,15 +174,14 @@ async function main() {
       process.exit(1);
     }
 
-    const systemPython = await findPython();
-    const venvPython = await ensureVenv(systemPython);
+    const venvPython = (await reusableVenv()) || (await ensureVenv(await findPython()));
     await ensureDependencies(venvPython);
 
     // 启动 MCP 服务器
     console.error("巨潮资讯 MCP 服务器已启动，等待连接...");
     const child = spawn(venvPython, [PYTHON_SCRIPT], {
       stdio: "inherit",
-      shell: process.platform === "win32",
+      shell: false,
       env: {
         ...process.env,
         PYTHONPATH: path.join(__dirname, "..", "python"),

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "postinstall": "node scripts/install-python-deps.js",
     "start": "node bin/cninfo-mcp.js",
     "dev": "node bin/cninfo-mcp.js",
-    "test": "python3 -m pytest python/test_spider.py -q"
+    "test": "python3 -m pytest python -q && node --test scripts/test-launcher.js"
   },
   "dependencies": {
     "spawn-please": "^2.0.2"

--- a/python/mcp_server.py
+++ b/python/mcp_server.py
@@ -15,11 +15,14 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from mcp.server.mcpserver import MCPServer
 from spider import (
     query_reports,
+    QueryError,
+    normalize_stock_code,
     download_reports,
     format_reports,
     saving_path,
     supported_report_types,
 )
+
 
 def _package_version(default: str = "0.0.0") -> str:
     """从 package.json 读取版本，避免与 npm 包版本各写一份而漂移。
@@ -63,7 +66,8 @@ def query_annual_reports_tool(
 
     Returns:
         Dictionary containing:
-        - success: Boolean indicating if the query was successful
+        - success: True only for complete queries, including empty results
+        - status: complete, partial, or error; incomplete queries include error details
         - stock_code: The queried stock code
         - report_type: The requested report type
         - year: The filtered year (if any)
@@ -71,11 +75,13 @@ def query_annual_reports_tool(
         - reports: List of report details (announcementTitle, announcementTime, secCode, secName, adjunctUrl)
     """
     try:
+        stock_code = normalize_stock_code(stock_code)
         reports = query_reports(stock_code, report_type, year)
 
         if not reports:
             return {
-                "success": False,
+                "success": True,
+                "status": "complete",
                 "stock_code": stock_code,
                 "report_type": report_type,
                 "year": year,
@@ -87,6 +93,7 @@ def query_annual_reports_tool(
 
         return {
             "success": True,
+            "status": "complete",
             "stock_code": stock_code,
             "report_type": report_type,
             "year": year,
@@ -96,9 +103,24 @@ def query_annual_reports_tool(
             + (f" for year {year}" if year else ""),
         }
 
+    except QueryError as e:
+        return {
+            "success": False,
+            "status": e.status,
+            "stock_code": stock_code,
+            "report_type": report_type,
+            "year": year,
+            "count": len(e.reports),
+            "reports": format_reports(e.reports),
+            "errors": e.errors,
+            "error": str(e),
+            "message": f"Query incomplete: {str(e)}",
+        }
+
     except Exception as e:
         return {
             "success": False,
+            "status": "error",
             "stock_code": stock_code,
             "report_type": report_type,
             "year": year,
@@ -127,7 +149,11 @@ def download_annual_reports_tool(
 
     Returns:
         Dictionary containing:
-        - success: Boolean indicating if download was successful
+        - success: True only when the query and all downloads completed
+        - status: complete, partial, or error
+        - query_status: Whether the source query completed
+        - files / failures: Successful paths and per-attachment errors
+        - failed: Number of failed attachments
         - stock_code: The stock code
         - report_type: The requested report type
         - year: The filtered year (if any)
@@ -137,7 +163,7 @@ def download_annual_reports_tool(
     """
     try:
         output_dir = save_path or saving_path
-        os.makedirs(output_dir, exist_ok=True)
+        stock_code = normalize_stock_code(stock_code)
 
         result = download_reports(
             stock_code, report_type, year=year, save_path=output_dir
@@ -151,10 +177,15 @@ def download_annual_reports_tool(
     except Exception as e:
         return {
             "success": False,
+            "status": "error",
             "stock_code": stock_code,
             "report_type": report_type,
             "year": year,
             "downloaded": 0,
+            "files": [],
+            "failed": 0,
+            "failures": [],
+            "query_status": "error",
             "path": save_path or saving_path,
             "error": str(e),
             "message": f"Error downloading reports: {str(e)}. Supported report_type values: {_supported_report_types_text()}",
@@ -165,12 +196,21 @@ def download_annual_reports_tool(
 def get_annual_reports_list(stock_code: str) -> str:
     """返回指定股票代码的年度报告格式化列表"""
     try:
-        reports = query_reports(stock_code, "annual")
+        warning = ""
+        try:
+            reports = query_reports(stock_code, "annual")
+        except QueryError as exc:
+            reports = exc.reports
+            warning = f"Query incomplete ({exc.status}): {exc}"
 
+        if not reports and warning:
+            return warning
         if not reports:
             return f"No annual reports found for stock {stock_code}"
 
         output = [f"Annual Reports for {stock_code}:", "=" * 60]
+        if warning:
+            output.append(warning)
 
         for report in reports:
             title = report.get("announcementTitle", "N/A")

--- a/python/spider.py
+++ b/python/spider.py
@@ -3,12 +3,15 @@
 """
 
 import datetime
+import hashlib
 import logging
 import os
 import random
 import re
+import tempfile
 import time
 from typing import Optional, Union
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import requests
 
@@ -167,6 +170,46 @@ def normalize_report_type(report_type: Optional[str]) -> str:
     return normalized
 
 
+def normalize_stock_code(stock_code) -> str:
+    """Require a six-digit security code; preserve leading zeroes."""
+    code = str(stock_code).strip()
+    if not re.fullmatch(r"[0-9]{6}", code):
+        raise ValueError("stock_code must contain exactly six ASCII digits")
+    return code
+
+
+class QueryError(RuntimeError):
+    """An incomplete query, optionally carrying already fetched reports."""
+
+    def __init__(self, errors, reports=None, partial=False):
+        self.errors = errors
+        self.reports = reports or []
+        self.status = "partial" if partial else "error"
+        super().__init__("; ".join(errors))
+
+
+def resolve_attachment_url(value: str, base: str = download_path) -> str:
+    """Resolve attachment paths, allowing only HTTPS on CNINFO's static host."""
+    if (
+        not isinstance(value, str)
+        or not value
+        or re.search(r"[\s\\\x00-\x1f\x7f]", value)
+    ):
+        raise ValueError("Invalid attachment URL")
+    parsed = urlsplit(urljoin(base, value))
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "static.cninfo.com.cn"
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.port not in (None, 443)
+    ):
+        raise ValueError("Attachment URLs must use https://static.cninfo.com.cn")
+    return urlunsplit(
+        ("https", "static.cninfo.com.cn", parsed.path or "/", parsed.query, "")
+    )
+
+
 def format_reports(reports: list) -> list:
     """提取公告中稳定、有用的字段，并把附件路径补全为可访问的绝对 URL。
 
@@ -176,15 +219,23 @@ def format_reports(reports: list) -> list:
     formatted = []
     for report in reports:
         adj = report.get("adjunctUrl", "")
+        attachment_error = None
+        try:
+            url = resolve_attachment_url(adj) if adj else ""
+        except ValueError as exc:
+            url = ""
+            attachment_error = str(exc)
         formatted.append(
             {
                 "announcementTitle": report.get("announcementTitle", ""),
                 "announcementTime": report.get("announcementTime", ""),
                 "secCode": report.get("secCode", ""),
                 "secName": report.get("secName", ""),
-                "adjunctUrl": download_path + adj if adj else "",
+                "adjunctUrl": url,
             }
         )
+        if attachment_error:
+            formatted[-1]["attachmentError"] = attachment_error
     return formatted
 
 
@@ -229,9 +280,12 @@ def _post_json(url: str, data: dict) -> dict:
 def _query_announcements(query: dict) -> list:
     """调用公告查询接口并返回 announcements 列表（带重试）。"""
     result = _post_json(QUERY_URL, query)
-    if result and "announcements" in result and result["announcements"]:
-        return result["announcements"]
-    return []
+    if not isinstance(result, dict) or "announcements" not in result:
+        raise ValueError("Invalid announcement response")
+    items = result["announcements"]
+    if items is not None and not isinstance(items, list):
+        raise ValueError("Invalid announcements list")
+    return items or []
 
 
 def _is_bse_code(stock_code) -> bool:
@@ -253,13 +307,10 @@ def _resolve_org_id(stock_code) -> Optional[tuple]:
     优先返回 code 完全等于输入的条目；找不到精确匹配则取第一条
     （同一公司新旧代码共用同一 orgId）。无结果返回 None。
     """
-    try:
-        hits = _post_json(TOP_SEARCH_URL, {"keyWord": stock_code, "maxNum": 10})
-    except Exception as e:
-        logger.warning("orgId 解析失败（%s）: %s", stock_code, e)
-        return None
-
-    if not isinstance(hits, list) or not hits:
+    hits = _post_json(TOP_SEARCH_URL, {"keyWord": stock_code, "maxNum": 10})
+    if not isinstance(hits, list):
+        raise ValueError("Invalid orgId response")
+    if not hits:
         return None
 
     target = re.sub(r"\D", "", str(stock_code or ""))
@@ -288,14 +339,17 @@ def _paginate(fetch_fn, stock):
     """
     all_items = []
     for page in range(1, MAX_PAGES + 1):
-        items = fetch_fn(page, stock)
+        try:
+            items = fetch_fn(page, stock)
+        except Exception as exc:
+            raise QueryError([f"page {page}: {exc}"], all_items, page > 1) from exc
         if not items:
             break
         all_items.extend(items)
         if len(items) < PAGE_SIZE:
             break
     else:
-        logger.warning("翻页达到上限 %s，结果可能被截断（%s）", MAX_PAGES, stock)
+        raise QueryError([f"Pagination limit reached ({MAX_PAGES})"], all_items, True)
     return all_items
 
 
@@ -453,68 +507,141 @@ def sseStock(page, stock):
     return _query_exchange_report(page, stock, "prospectus", "sse", "sh")
 
 
+def _get_attachment(url):
+    """Follow at most five redirects, validating before every network request."""
+    url = resolve_attachment_url(url)
+    for redirects in range(6):
+        response = requests.get(
+            url,
+            headers={"User-Agent": random.choice(User_Agent)},
+            timeout=30,
+            allow_redirects=False,
+        )
+        if response.status_code not in (301, 302, 303, 307, 308):
+            return response
+        try:
+            if redirects == 5:
+                raise ValueError("Too many attachment redirects")
+            url = resolve_attachment_url(response.headers.get("Location", ""), base=url)
+        finally:
+            response.close()
+    raise RuntimeError("Attachment redirect handling failed")
+
+
+def _fetch_pdf(url):
+    for attempt in range(MAX_RETRIES):
+        try:
+            response = _get_attachment(url)
+            try:
+                response.raise_for_status()
+                content = response.content
+                content_type = (
+                    response.headers.get("Content-Type", "")
+                    .lower()
+                    .split(";", 1)[0]
+                    .strip()
+                )
+                if content_type and content_type not in (
+                    "application/pdf",
+                    "application/octet-stream",
+                    "binary/octet-stream",
+                    "application/x-pdf",
+                ):
+                    raise ValueError(f"Unexpected PDF content type: {content_type}")
+                if not content.startswith(b"%PDF-"):
+                    raise ValueError("Empty or non-PDF response")
+                return content
+            finally:
+                response.close()
+        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
+            if attempt == MAX_RETRIES - 1:
+                raise
+        except requests.exceptions.HTTPError as exc:
+            status = exc.response.status_code if exc.response is not None else None
+            if status != 429 and (status is None or status < 500):
+                raise
+            if attempt == MAX_RETRIES - 1:
+                raise
+        time.sleep(RETRY_BACKOFF * (2**attempt) + random.random())
+    raise RuntimeError("No download attempts configured")
+
+
 def Download(
     single_page,
     report_type: Optional[str] = None,
     year_filter: Optional[Union[int, str]] = None,
     save_path: Optional[str] = None,
+    *,
+    details=False,
 ):
-    """下载公告列表中的 PDF 文件。"""
-    if single_page is None:
-        return 0
-
-    output_dir = (save_path or saving_path).rstrip("/\\") + "/"
-    downloaded_count = 0
+    """Download independently and atomically; legacy callers receive a count."""
+    output_dir = save_path or saving_path
+    files, failures = [], []
     normalized_type = normalize_report_type(report_type) if report_type else None
-
-    for i in single_page:
-        title = i.get("announcementTitle", "")
-        if normalized_type:
-            should_download = _is_report_title(
-                title, normalized_type, year_filter=year_filter
-            )
-        else:
-            should_download = any(
-                _is_report_title(title, candidate, year_filter=year_filter)
-                for candidate in REPORT_TYPE_SPECS
-            )
-
-        if not should_download:
+    for report in single_page or []:
+        title = report.get("announcementTitle", "")
+        types = [normalized_type] if normalized_type else REPORT_TYPE_SPECS
+        if not any(_is_report_title(title, kind, year_filter) for kind in types):
             continue
-
-        adjunct_url = i.get("adjunctUrl", "")
-        if not adjunct_url:
-            logger.warning("公告缺少 adjunctUrl，跳过：%s", title)
-            continue
-
-        download = download_path + adjunct_url
-        name = _sanitize_filename(
-            i.get("secCode", "") + "_" + i.get("secName", "") + "_" + title + ".pdf"
-        )
-        file_path = output_dir + name
-
-        logger.info("↓ %s", name)
-        os.makedirs(output_dir, exist_ok=True)
-
-        time.sleep(random.random() * 2)
-
-        r = requests.get(
-            download, headers={"User-Agent": random.choice(User_Agent)}, timeout=30
-        )
-        r.raise_for_status()
-        with open(file_path, "wb") as f:
-            f.write(r.content)
-        downloaded_count += 1
-
-    return downloaded_count
+        adjunct_url = report.get("adjunctUrl", "")
+        temporary_path = None
+        try:
+            if not adjunct_url:
+                raise ValueError("Missing adjunctUrl")
+            url = resolve_attachment_url(adjunct_url)
+            # Full attachment digest keeps distinct URLs distinct, even with identical titles.
+            attachment_id = hashlib.sha256(adjunct_url.encode("utf-8")).hexdigest()
+            stem = _sanitize_filename(
+                f"{report.get('secCode', '')}_{report.get('secName', '')}_{title}"
+            )
+            # Leave room for the digest on filesystems with a 255-byte name limit.
+            stem = stem.encode("utf-8")[:160].decode("utf-8", errors="ignore")
+            file_path = os.path.join(output_dir, f"{stem}_{attachment_id}.pdf")
+            time.sleep(random.random() * 2)
+            content = _fetch_pdf(url)
+            os.makedirs(output_dir, exist_ok=True)
+            with tempfile.NamedTemporaryFile(
+                dir=output_dir, suffix=".tmp", delete=False
+            ) as fh:
+                temporary_path = fh.name
+                fh.write(content)
+            os.replace(temporary_path, file_path)
+            temporary_path = None
+            files.append({"adjunctUrl": adjunct_url, "path": file_path})
+        except Exception as exc:
+            failures.append(
+                {
+                    "adjunctUrl": adjunct_url,
+                    "announcementTitle": title,
+                    "error": str(exc),
+                }
+            )
+            logger.warning("Download failed (%s): %s", title, exc)
+        finally:
+            if temporary_path is not None:
+                try:
+                    os.unlink(temporary_path)
+                except OSError as exc:
+                    logger.warning(
+                        "Could not remove temporary file %s: %s", temporary_path, exc
+                    )
+    result = {
+        "downloaded": len(files),
+        "files": files,
+        "failed": len(failures),
+        "failures": failures,
+    }
+    return result if details else len(files)
 
 
 def query_reports(stock_code, report_type="annual", year=None):
-    """查询指定股票和报告类型的公告列表。"""
+    """Return complete results or raise QueryError carrying partial reports."""
+    stock_code = normalize_stock_code(stock_code)
     normalized_type = normalize_report_type(report_type)
     all_announcements = []
-    requested_code = re.sub(r"\D", "", str(stock_code or ""))
-    allowed_sec_codes = {requested_code} if requested_code else set()
+    allowed_sec_codes = {stock_code}
+    errors = []
+    partial = False
 
     exchanges = [
         ("sse", "sh", "沪市"),
@@ -526,7 +653,12 @@ def query_reports(stock_code, report_type="annual", year=None):
                 page, stock_code, normalized_type, c, p
             )
             all_announcements.extend(_paginate(fetch_fn, stock_code))
+            partial = True
         except Exception as e:
+            errors.append(f"{label}: {e}")
+            if isinstance(e, QueryError):
+                all_announcements.extend(e.reports)
+                partial = partial or e.status == "partial"
             logger.warning(
                 "%s%s查询失败: %s",
                 label,
@@ -550,7 +682,14 @@ def query_reports(stock_code, report_type="annual", year=None):
                     stock_value=stock_value,
                 )
                 all_announcements.extend(_paginate(fetch_fn, stock_value))
+                partial = True
+            else:
+                raise ValueError(f"Could not resolve orgId for {stock_code}")
         except Exception as e:
+            errors.append(f"北交所: {e}")
+            if isinstance(e, QueryError):
+                all_announcements.extend(e.reports)
+                partial = partial or e.status == "partial"
             logger.warning(
                 "北交所%s查询失败: %s",
                 REPORT_TYPE_SPECS[normalized_type]["label"],
@@ -580,41 +719,43 @@ def query_reports(stock_code, report_type="annual", year=None):
             continue
         filtered.append(announcement)
 
+    if errors:
+        raise QueryError(errors, filtered, partial)
     return filtered
 
 
 def download_reports(stock_code, report_type="annual", year=None, save_path=None):
     """下载指定股票和报告类型的 PDF。"""
+    stock_code = normalize_stock_code(stock_code)
     normalized_type = normalize_report_type(report_type)
-    label = REPORT_TYPE_SPECS[normalized_type]["label"]
-    announcements = query_reports(stock_code, normalized_type, year)
-
-    if not announcements:
-        return {
-            "success": False,
-            "message": f"未找到股票 {stock_code} 的{label}"
-            + (f"（{year} 年）" if year else ""),
-            "downloaded": 0,
-        }
-
+    query_error = None
+    try:
+        announcements = query_reports(stock_code, normalized_type, year)
+    except QueryError as exc:
+        query_error = exc
+        announcements = exc.reports
     output_dir = save_path or saving_path
-    count = Download(
-        announcements,
-        report_type=normalized_type,
-        year_filter=year,
-        save_path=output_dir,
+    result = Download(announcements, normalized_type, year, output_dir, details=True)
+    status = "complete"
+    if query_error or result["failed"]:
+        status = (
+            "partial"
+            if result["downloaded"] or (query_error and query_error.status == "partial")
+            else "error"
+        )
+    result.update(
+        success=status == "complete",
+        status=status,
+        query_status=query_error.status if query_error else "complete",
+        path=output_dir,
+        message=f"Downloaded {result['downloaded']} file(s); {result['failed']} failed. Status: {status}.",
     )
-
-    downloaded = count or 0
-    year_suffix = f"（{year} 年）" if year else ""
-    return {
-        "success": downloaded > 0,
-        "message": f"已下载 {stock_code} {label}{year_suffix}，共 {downloaded} 个文件"
-        if downloaded > 0
-        else f"未下载任何文件（{stock_code} {label}{year_suffix}）",
-        "downloaded": downloaded,
-        "path": output_dir,
-    }
+    if query_error:
+        result["query_errors"] = query_error.errors
+        result["error"] = str(query_error)
+    elif result["failed"]:
+        result["error"] = f"{result['failed']} download(s) failed"
+    return result
 
 
 def query_annual_reports(stock_code, year=None):

--- a/python/spider.py
+++ b/python/spider.py
@@ -368,8 +368,10 @@ def _is_report_title(
     spec = REPORT_TYPE_SPECS[normalized_type]
 
     if normalized_type == "prospectus":
+        # Historical version labels vary; filter document kind below instead
+        # of restricting prospectus versions to a fixed suffix vocabulary.
         match = re.fullmatch(
-            r".*?(?:招股说明书|招股意向书|招股书)(?:[（(](?:申报稿|上会稿|注册稿|注册生效稿|发行稿|更新后)[)）])?",
+            r".*?(?:招股说明书|招股意向书|招股书)(?:\([^()（）]+\)|（[^()（）]+）)*",
             compact_title,
         )
         if not match:
@@ -383,6 +385,9 @@ def _is_report_title(
             "问询",
             "回复",
             "公告",
+            "审计报告",
+            "附件",
+            "附录",
         ]
         return not any(kw in remainder for kw in excluded)
 

--- a/python/spider.py
+++ b/python/spider.py
@@ -314,13 +314,23 @@ def _is_report_title(
     spec = REPORT_TYPE_SPECS[normalized_type]
 
     if normalized_type == "prospectus":
-        matched = next((kw for kw in spec["keywords"] if kw in compact_title), None)
-        if matched is None:
+        match = re.fullmatch(
+            r".*?(?:招股说明书|招股意向书|招股书)(?:[（(](?:申报稿|上会稿|注册稿|注册生效稿|发行稿|更新后)[)）])?",
+            compact_title,
+        )
+        if not match:
             return False
-        # 去掉招股书正式名称后再判断摘要/更正等变体，避免“招股说明书”自带的
-        # “说明”被 COMMON_EXCLUDE_KEYWORDS 误伤（参见 #2）。
-        remainder = compact_title.replace(matched, "")
-        return not any(kw in remainder for kw in COMMON_EXCLUDE_KEYWORDS)
+        remainder = re.sub(r"招股说明书|招股意向书|招股书", "", compact_title)
+        excluded = COMMON_EXCLUDE_KEYWORDS + [
+            "关于",
+            "意见",
+            "核查",
+            "验证",
+            "问询",
+            "回复",
+            "公告",
+        ]
+        return not any(kw in remainder for kw in excluded)
 
     # 摘要/更正/修订等非正文变体应排除
     if any(keyword in compact_title for keyword in COMMON_EXCLUDE_KEYWORDS):

--- a/python/spider.py
+++ b/python/spider.py
@@ -363,7 +363,8 @@ def _matches_year(
         # announcementTime 通常是 "YYYY-MM-DD" 字符串；个别接口可能返回 epoch 毫秒
         if isinstance(announcement_time, (int, float)):
             announcement_time = datetime.datetime.fromtimestamp(
-                announcement_time / 1000
+                announcement_time / 1000,
+                tz=datetime.timezone(datetime.timedelta(hours=8)),
             ).strftime("%Y-%m-%d")
         return str(announcement_time).startswith(str(year))
     return _is_report_title(

--- a/python/test_mcp_server.py
+++ b/python/test_mcp_server.py
@@ -1,0 +1,45 @@
+from unittest.mock import Mock
+
+import mcp_server
+from spider import QueryError
+
+
+def test_query_empty_is_complete(monkeypatch):
+    monkeypatch.setattr(mcp_server, "query_reports", lambda *args: [])
+    result = mcp_server.query_annual_reports_tool("000001")
+    assert result["success"] is True
+    assert result["status"] == "complete"
+    assert result["count"] == 0
+
+
+def test_query_partial_reports_survive_tool_and_resource(monkeypatch):
+    rows = [{"secCode": "000001", "announcementTitle": "2024年年度报告"}]
+    monkeypatch.setattr(
+        mcp_server,
+        "query_reports",
+        Mock(side_effect=QueryError(["page two failed"], rows, True)),
+    )
+    result = mcp_server.query_annual_reports_tool("000001")
+    assert result["status"] == "partial"
+    assert result["count"] == 1
+    assert result["error"] == "page two failed"
+    resource = mcp_server.get_annual_reports_list("000001")
+    assert "Query incomplete" in resource
+    assert "2024年年度报告" in resource
+
+
+def test_query_outage_is_error(monkeypatch):
+    monkeypatch.setattr(
+        mcp_server, "query_reports", Mock(side_effect=QueryError(["offline"]))
+    )
+    result = mcp_server.query_annual_reports_tool("000001")
+    assert result["status"] == "error"
+    assert result["success"] is False
+    assert "No annual reports found" not in result["message"]
+
+
+def test_invalid_download_does_not_create_directory(tmp_path):
+    target = tmp_path / "invalid"
+    result = mcp_server.download_annual_reports_tool("", save_path=str(target))
+    assert result["status"] == "error"
+    assert not target.exists()

--- a/python/test_spider.py
+++ b/python/test_spider.py
@@ -157,7 +157,194 @@ def test_matches_year_non_prospectus_uses_title():
     assert _matches_year(ann, "annual", 2023) is False
 
 
+# Failure-path regressions use only mocked HTTP responses.
+import os
+from pathlib import Path
+from unittest.mock import Mock
+
+import requests
 import spider
+
+
+def report(url="a.pdf", code="000001"):
+    return {
+        "secCode": code,
+        "secName": "公司",
+        "announcementTitle": "2024年年度报告",
+        "adjunctUrl": url,
+    }
+
+
+@pytest.mark.parametrize(
+    "code",
+    ["", "  ", None, "abc", "00001", "0000001", "SZ000001", "０００００１", "000 001"],
+)
+def test_invalid_stock_has_no_side_effects(monkeypatch, tmp_path, code):
+    def unexpected(*args, **kwargs):
+        pytest.fail("Invalid input must not make requests")
+
+    monkeypatch.setattr(spider.requests, "post", unexpected)
+    target = tmp_path / "downloads"
+    with pytest.raises(ValueError, match="six ASCII digits"):
+        spider.download_reports(code, save_path=str(target))
+    assert not target.exists()
+
+
+def test_normalized_code_scopes_query_and_filter(monkeypatch):
+    seen = []
+
+    def fetch(page, code, *args):
+        seen.append(code)
+        return [report(), report(code="000002")]
+
+    monkeypatch.setattr(spider, "_query_exchange_report", fetch)
+    assert spider.query_reports(" 000001 ") == [report()]
+    assert seen == ["000001", "000001"]
+
+
+def test_query_outage_is_not_empty_success(monkeypatch):
+    monkeypatch.setattr(
+        spider, "_query_exchange_report", Mock(side_effect=requests.Timeout("offline"))
+    )
+    with pytest.raises(spider.QueryError) as caught:
+        spider.query_reports("000001")
+    assert caught.value.status == "error"
+    assert caught.value.reports == []
+    assert len(caught.value.errors) == 2
+
+
+def test_query_preserves_page_one(monkeypatch):
+    rows = [report(f"{i}.pdf") for i in range(spider.PAGE_SIZE)]
+
+    def fetch(page, code, kind, column, plate):
+        if column == "szse":
+            return []
+        if page == 2:
+            raise requests.Timeout("page two")
+        return rows
+
+    monkeypatch.setattr(spider, "_query_exchange_report", fetch)
+    with pytest.raises(spider.QueryError) as caught:
+        spider.query_reports("000001")
+    assert caught.value.status == "partial"
+    assert caught.value.reports == rows
+    assert "page 2" in str(caught.value)
+
+
+def test_pagination_limit_is_partial(monkeypatch):
+    monkeypatch.setattr(spider, "MAX_PAGES", 1)
+    with pytest.raises(spider.QueryError, match="Pagination limit") as caught:
+        spider._paginate(lambda *args: [report()] * spider.PAGE_SIZE, "000001")
+    assert len(caught.value.reports) == spider.PAGE_SIZE
+
+
+def test_bse_resolution_failure_surfaces(monkeypatch):
+    monkeypatch.setattr(spider, "_query_exchange_report", lambda *a: [])
+    monkeypatch.setattr(
+        spider, "_post_json", Mock(side_effect=requests.Timeout("org offline"))
+    )
+    with pytest.raises(spider.QueryError, match="org offline"):
+        spider.query_reports("920001")
+
+
+def test_bse_migrated_code_remains_allowed(monkeypatch):
+    monkeypatch.setattr(spider, "_resolve_org_id", lambda code: ("920001", "org123"))
+
+    def fetch(page, code, kind, column, plate, **kwargs):
+        if column == "bj":
+            assert kwargs["stock_value"] == "920001,org123"
+            return [report(code="920001"), report(code="920002")]
+        return []
+
+    monkeypatch.setattr(spider, "_query_exchange_report", fetch)
+    assert spider.query_reports("830001") == [report(code="920001")]
+
+
+@pytest.fixture
+def pdf_http(monkeypatch):
+    monkeypatch.setattr(spider.time, "sleep", lambda *a: None)
+
+    def response(body=b"%PDF-1.7\nexample", content_type="application/pdf"):
+        result = Mock(
+            content=body, headers={"Content-Type": content_type}, status_code=200
+        )
+        result.raise_for_status.return_value = None
+        return result
+
+    return response
+
+
+def test_distinct_attachments_and_atomic_failure(monkeypatch, tmp_path, pdf_http):
+    monkeypatch.setattr(
+        spider.requests,
+        "get",
+        Mock(side_effect=[pdf_http(b"%PDF-first"), pdf_http(b"%PDF-second")]),
+    )
+    rows = [report("one.pdf"), report("two.pdf")]
+    result = spider.Download(rows, save_path=str(tmp_path), details=True)
+    paths = [Path(f["path"]) for f in result["files"]]
+    assert result["downloaded"] == 2
+    assert paths[0] != paths[1]
+    assert [p.read_bytes() for p in paths] == [b"%PDF-first", b"%PDF-second"]
+    monkeypatch.setattr(
+        spider.requests, "get", lambda *a, **kw: pdf_http(b"%PDF-replacement")
+    )
+    monkeypatch.setattr(spider.os, "replace", Mock(side_effect=OSError("disk error")))
+    result = spider.Download(rows[:1], save_path=str(tmp_path), details=True)
+    assert result["failed"] == 1
+    assert paths[0].read_bytes() == b"%PDF-first"
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_download_continues_after_failure(monkeypatch, tmp_path, pdf_http):
+    monkeypatch.setattr(
+        spider, "query_reports", lambda *a: [report(f"{i}.pdf") for i in range(3)]
+    )
+    get = Mock(
+        side_effect=[pdf_http()]
+        + [requests.Timeout("timeout")] * spider.MAX_RETRIES
+        + [pdf_http()]
+    )
+    monkeypatch.setattr(spider.requests, "get", get)
+    result = spider.download_reports("000001", save_path=str(tmp_path))
+    assert result["downloaded"] == 2
+    assert result["failed"] == 1
+    assert result["status"] == "partial"
+    assert result["success"] is False
+    assert result["failures"][0]["adjunctUrl"] == "1.pdf"
+    assert len(list(tmp_path.glob("*.pdf"))) == 2
+    assert get.call_count == 2 + spider.MAX_RETRIES
+
+
+@pytest.mark.parametrize(
+    "body,kind",
+    [
+        (b"", "application/pdf"),
+        (b"<html>denied</html>", "application/pdf"),
+        (b"%PDF-fake", "text/html"),
+    ],
+)
+def test_invalid_pdf_not_saved(monkeypatch, tmp_path, pdf_http, body, kind):
+    get = Mock(return_value=pdf_http(body, kind))
+    monkeypatch.setattr(spider.requests, "get", get)
+    result = spider.Download([report()], save_path=str(tmp_path), details=True)
+    assert result["downloaded"] == 0
+    assert result["failed"] == 1
+    assert not list(tmp_path.iterdir())
+    assert get.call_count == 1
+
+
+def test_partial_query_can_download_retained_reports(monkeypatch, tmp_path, pdf_http):
+    monkeypatch.setattr(
+        spider,
+        "query_reports",
+        Mock(side_effect=spider.QueryError(["page 2 failed"], [report()], True)),
+    )
+    monkeypatch.setattr(spider.requests, "get", lambda *a, **kw: pdf_http())
+    result = spider.download_reports("000001", save_path=str(tmp_path))
+    assert result["downloaded"] == 1
+    assert result["query_status"] == result["status"] == "partial"
+    assert result["query_errors"] == ["page 2 failed"]
 
 
 @pytest.mark.parametrize(
@@ -181,9 +368,6 @@ def test_prospectus_document_versions(suffix):
     )
 
 
-import os
-
-
 @pytest.mark.skipif(not hasattr(spider.time, "tzset"), reason="tzset unavailable")
 @pytest.mark.parametrize("zone", ["Asia/Shanghai", "UTC", "America/Edmonton"])
 def test_prospectus_china_new_year(monkeypatch, zone):
@@ -204,3 +388,128 @@ def test_prospectus_china_new_year(monkeypatch, zone):
         else:
             os.environ["TZ"] = previous
         spider.time.tzset()
+
+
+@pytest.mark.parametrize(
+    "status,attempts,downloaded", [(404, 1, 0), (429, 2, 1), (503, 2, 1)]
+)
+def test_download_http_retry_policy(
+    monkeypatch, tmp_path, pdf_http, status, attempts, downloaded
+):
+    bad = requests.Response()
+    bad.status_code = status
+    bad._content = b"error"
+    bad._content_consumed = True
+    get = Mock(side_effect=[bad, pdf_http()])
+    monkeypatch.setattr(spider.requests, "get", get)
+    result = spider.Download([report()], save_path=str(tmp_path), details=True)
+    assert get.call_count == attempts
+    assert result["downloaded"] == downloaded
+
+
+def test_download_empty_query_is_complete(monkeypatch, tmp_path):
+    monkeypatch.setattr(spider, "query_reports", lambda *args: [])
+    target = tmp_path / "absent"
+    result = spider.download_reports("000001", save_path=str(target))
+    assert result["success"] is True
+    assert result["status"] == "complete"
+    assert result["downloaded"] == result["failed"] == 0
+    assert not target.exists()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "folder/report.pdf",
+        "/folder/report.pdf",
+        "https://static.cninfo.com.cn/folder/report.pdf",
+        "//static.cninfo.com.cn/folder/report.pdf",
+    ],
+)
+def test_attachment_urls_shared_by_format_and_download(
+    monkeypatch, tmp_path, pdf_http, value
+):
+    expected = "https://static.cninfo.com.cn/folder/report.pdf"
+    assert spider.format_reports([report(value)])[0]["adjunctUrl"] == expected
+    get = Mock(return_value=pdf_http())
+    monkeypatch.setattr(spider.requests, "get", get)
+    assert spider.Download([report(value)], save_path=str(tmp_path)) == 1
+    assert get.call_args.args[0] == expected
+    assert get.call_args.kwargs["allow_redirects"] is False
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://example.org/report.pdf",
+        "//127.0.0.1/report.pdf",
+        "https://static.cninfo.com.cn.example.org/report.pdf",
+        "https://static.cninfo.com.cn@evil.example/report.pdf",
+        "https://user@static.cninfo.com.cn/report.pdf",
+        "https://static.cninfo.com.cn:8443/report.pdf",
+        "http://static.cninfo.com.cn/report.pdf",
+        "file:///etc/passwd",
+        "https://static.cninfo.com.cn\\@evil.example/report.pdf",
+        "https://static.cninfo.com.cn/\nreport.pdf",
+    ],
+)
+def test_unsafe_attachment_never_requested_or_linked(monkeypatch, tmp_path, value):
+    get = Mock(side_effect=AssertionError("must not request unsafe URL"))
+    monkeypatch.setattr(spider.requests, "get", get)
+    formatted = spider.format_reports([report(value)])[0]
+    assert formatted["adjunctUrl"] == ""
+    assert formatted["attachmentError"]
+    result = spider.Download([report(value)], save_path=str(tmp_path), details=True)
+    assert result["failed"] == 1
+    assert result["downloaded"] == 0
+    get.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "location",
+    [
+        "https://evil.example/a.pdf",
+        "//127.0.0.1/a.pdf",
+        "http://static.cninfo.com.cn/a.pdf",
+        "",
+    ],
+)
+def test_redirect_rejected_before_following(monkeypatch, pdf_http, location):
+    redirect = Mock(status_code=302, headers={"Location": location})
+    get = Mock(return_value=redirect)
+    monkeypatch.setattr(spider.requests, "get", get)
+    with pytest.raises(ValueError):
+        spider._fetch_pdf("https://static.cninfo.com.cn/a.pdf")
+    assert get.call_count == 1
+    assert get.call_args.kwargs["allow_redirects"] is False
+    redirect.close.assert_called_once()
+
+
+def test_safe_relative_redirects_and_later_unsafe_hop(monkeypatch, pdf_http):
+    first = Mock(status_code=302, headers={"Location": "../new.pdf"})
+    good = pdf_http()
+    get = Mock(side_effect=[first, good])
+    monkeypatch.setattr(spider.requests, "get", get)
+    assert spider._fetch_pdf("https://static.cninfo.com.cn/folder/a.pdf").startswith(
+        b"%PDF-"
+    )
+    assert get.call_args_list[1].args[0] == "https://static.cninfo.com.cn/new.pdf"
+    first.close.assert_called_once()
+    good.close.assert_called_once()
+    second = Mock(status_code=307, headers={"Location": "https://evil.example/a.pdf"})
+    get.reset_mock(side_effect=True)
+    get.side_effect = [first, second]
+    with pytest.raises(ValueError):
+        spider._fetch_pdf("https://static.cninfo.com.cn/folder/a.pdf")
+    assert get.call_count == 2
+    second.close.assert_called_once()
+
+
+def test_redirect_loop_is_bounded(monkeypatch, pdf_http):
+    response = Mock(status_code=308, headers={"Location": "/loop.pdf"})
+    get = Mock(return_value=response)
+    monkeypatch.setattr(spider.requests, "get", get)
+    with pytest.raises(ValueError, match="Too many"):
+        spider._fetch_pdf("loop.pdf")
+    assert get.call_count == 6
+    assert response.close.call_count == 6

--- a/python/test_spider.py
+++ b/python/test_spider.py
@@ -179,3 +179,28 @@ def test_prospectus_document_versions(suffix):
     assert spider._is_report_title(
         "某公司首次公开发行股票并上市招股说明书" + suffix, "prospectus"
     )
+
+
+import os
+
+
+@pytest.mark.skipif(not hasattr(spider.time, "tzset"), reason="tzset unavailable")
+@pytest.mark.parametrize("zone", ["Asia/Shanghai", "UTC", "America/Edmonton"])
+def test_prospectus_china_new_year(monkeypatch, zone):
+    previous = os.environ.get("TZ")
+    try:
+        os.environ["TZ"] = zone
+        spider.time.tzset()
+        # 2024-01-01 00:00:00 at UTC+08:00, independent of host timezone.
+        assert spider._matches_year(
+            {"announcementTime": 1704038400000}, "prospectus", 2024
+        )
+        assert not spider._matches_year(
+            {"announcementTime": 1704038399999}, "prospectus", 2024
+        )
+    finally:
+        if previous is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = previous
+        spider.time.tzset()

--- a/python/test_spider.py
+++ b/python/test_spider.py
@@ -155,3 +155,27 @@ def test_matches_year_non_prospectus_uses_title():
     ann = {"announcementTitle": "某公司2024年年度报告"}
     assert _matches_year(ann, "annual", 2024) is True
     assert _matches_year(ann, "annual", 2023) is False
+
+
+import spider
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "保荐机构关于招股说明书的核查意见",
+        "关于招股说明书",
+        "律师对招股说明书的验证报告",
+        "招股说明书问询回复",
+        "招股说明书（核查意见）",
+    ],
+)
+def test_prospectus_supporting_documents_excluded(title):
+    assert not spider._is_report_title(title, "prospectus")
+
+
+@pytest.mark.parametrize("suffix", ["", "（申报稿）", "（注册稿）", "(上会稿)"])
+def test_prospectus_document_versions(suffix):
+    assert spider._is_report_title(
+        "某公司首次公开发行股票并上市招股说明书" + suffix, "prospectus"
+    )

--- a/python/test_spider.py
+++ b/python/test_spider.py
@@ -355,13 +355,32 @@ def test_partial_query_can_download_retained_reports(monkeypatch, tmp_path, pdf_
         "律师对招股说明书的验证报告",
         "招股说明书问询回复",
         "招股说明书（核查意见）",
+        "招股说明书（预披露更新）（核查意见）",
+        "招股说明书（封卷稿）（摘要）",
+        "招股说明书（封卷稿）（英文）",
+        "招股说明书（审计报告）",
+        "招股说明书（附件）",
+        "招股说明书（附录）",
     ],
 )
 def test_prospectus_supporting_documents_excluded(title):
     assert not spider._is_report_title(title, "prospectus")
 
 
-@pytest.mark.parametrize("suffix", ["", "（申报稿）", "（注册稿）", "(上会稿)"])
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "",
+        "（申报稿）",
+        "（注册稿）",
+        "(上会稿)",
+        "（预披露更新）",
+        "(预披露更新)",
+        "（封卷稿）",
+        "(封卷稿)",
+        "（预披露更新）（2017年12月）",
+    ],
+)
 def test_prospectus_document_versions(suffix):
     assert spider._is_report_title(
         "某公司首次公开发行股票并上市招股说明书" + suffix, "prospectus"

--- a/scripts/install-python-deps.js
+++ b/scripts/install-python-deps.js
@@ -16,7 +16,7 @@ const REQUIREMENTS_FILE = path.join(
   "requirements.txt",
 );
 
-const VENV_DIR = path.join(os.homedir(), ".cninfo-mcp", "venv");
+let VENV_DIR = path.join(os.homedir(), ".cninfo-mcp", "venv");
 
 // 依赖探针：校验 venv 是否满足 requirements.txt 的全部约束
 const DEPS_CHECK = path.join(__dirname, "..", "python", "check_deps.py");
@@ -26,6 +26,26 @@ function getVenvPython() {
     return path.join(VENV_DIR, "Scripts", "python.exe");
   }
   return path.join(VENV_DIR, "bin", "python3");
+}
+
+async function isSupportedPython(cmd) {
+  try {
+    const result = await spawnCommand(cmd, ["--version"]);
+    const version = `${result.stdout || ""} ${result.stderr || ""}`.match(/\bPython (\d+)\.(\d+)\.(\d+)\b/);
+    return Boolean(version && Number(version[1]) === 3 && Number(version[2]) >= 10);
+  } catch {
+    return false;
+  }
+}
+
+// Preserve an obsolete environment and create a compatible sibling if needed.
+async function reusableVenv() {
+  if (!fs.existsSync(getVenvPython())) return null;
+  if (await isSupportedPython(getVenvPython())) return getVenvPython();
+  VENV_DIR += "-py310";
+  if (!fs.existsSync(getVenvPython())) return null;
+  if (await isSupportedPython(getVenvPython())) return getVenvPython();
+  throw new Error(`Unsupported or broken Python environment at ${VENV_DIR}. Recreate it with Python 3.10+.`);
 }
 
 async function findPython() {
@@ -38,22 +58,18 @@ async function findPython() {
   ];
 
   for (const cmd of pythonCommands) {
-    try {
-      const result = await spawnCommand(cmd, ["--version"]);
-      if (result.stdout && result.stdout.includes("Python")) {
-        return cmd;
-      }
-    } catch (error) {}
+    if (await isSupportedPython(cmd)) return cmd;
   }
 
   return null;
 }
 
-function spawnCommand(cmd, args) {
+function spawnCommand(cmd, args, options = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(cmd, args, {
       stdio: "pipe",
-      shell: process.platform === "win32",
+      ...options,
+      shell: false,
     });
     let stdout = "";
     let stderr = "";
@@ -79,18 +95,14 @@ async function main() {
     return;
   }
 
-  const pythonCmd = await findPython();
-  if (!pythonCmd) {
-    console.warn(
-      "⚠️  Python not found. Python dependencies will be installed on first run.",
-    );
-    console.warn("   Please install Python 3.10+ from https://python.org");
-    return;
-  }
-
-  // 创建虚拟环境（如果不存在）
-  const venvPython = getVenvPython();
-  if (!fs.existsSync(venvPython)) {
+  let venvPython = await reusableVenv();
+  if (!venvPython) {
+    const pythonCmd = await findPython();
+    if (!pythonCmd) {
+      console.warn("⚠️  Python 3.10+ not found. Dependencies will be installed on first run.");
+      return;
+    }
+    venvPython = getVenvPython();
     console.log("Creating Python virtual environment...");
     try {
       fs.mkdirSync(path.dirname(VENV_DIR), { recursive: true });

--- a/scripts/test-launcher.js
+++ b/scripts/test-launcher.js
@@ -1,0 +1,86 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const { EventEmitter } = require('node:events');
+
+function load(file, { versions = {}, existing = true, missingDeps = false, platform = 'win32' } = {}) {
+  const calls = [];
+  const fakeFs = { existsSync: () => existing, mkdirSync() {} };
+  const fakeProcess = { platform, env: {}, exit(code) { throw new Error(`exit ${code}`); } };
+  const context = {
+    __dirname: path.join('C:/Users/Jane Doe & Co/repo', path.dirname(file)),
+    process: fakeProcess,
+    console: { log() {}, warn() {}, error() {} },
+    require(name) {
+      if (name === 'fs') return fakeFs;
+      if (name === 'os') return { homedir: () => 'C:/Users/Jane Doe & Co' };
+      if (name !== 'child_process') return require(name);
+      return { spawn(cmd, args, options) {
+        calls.push({ cmd, args, options });
+        const child = new EventEmitter();
+        child.stdout = new EventEmitter();
+        child.stderr = new EventEmitter();
+        queueMicrotask(() => {
+          let code = 0;
+          if (args[0] === '--version') {
+            const version = versions[cmd] ?? versions.default;
+            if (version) child.stderr.emit('data', version);
+            else code = 1;
+          } else if (missingDeps && args[0].endsWith('check_deps.py')) code = 1;
+          child.emit('close', code);
+        });
+        return child;
+      } };
+    },
+  };
+  vm.createContext(context);
+  const source = fs.readFileSync(path.join(__dirname, '..', file), 'utf8')
+    .replace(/main\(\)(?:\.catch\(console.error\))?;\s*$/, '');
+  vm.runInContext(source, context);
+  return { calls, context, fakeFs, run: code => vm.runInContext(code, context) };
+}
+
+for (const file of ['bin/cninfo-mcp.js', 'scripts/install-python-deps.js']) {
+  test(`${file}: skips unsupported Python, accepts version on stderr`, async () => {
+    const app = load(file, { versions: { python3: 'Python 3.9.6', python: 'Python 2.7.18', 'python3.12': 'Python 3.12.0' } });
+    assert.equal(await app.run('findPython()'), 'python3.12');
+    assert.equal(app.calls.length, 3);
+  });
+
+  test(`${file}: prefers supported venv without system Python`, async () => {
+    const app = load(file, { versions: { default: 'Python 3.10.0' } });
+    await app.run('main()');
+    assert(app.calls.every(call => call.cmd.includes('Jane Doe & Co')));
+    assert(app.calls.every(call => call.options.shell === false));
+    assert(app.calls.every(call => Array.isArray(call.args)));
+    assert(!app.calls.some(call => call.args.includes('venv')));
+  });
+
+  test(`${file}: rejects unsupported cached venv and keeps it intact`, async () => {
+    const app = load(file, { versions: { default: 'Python 3.9.6' } });
+    app.fakeFs.existsSync = filename => !filename.includes('venv-py310');
+    assert.equal(await app.run('reusableVenv()'), null);
+    assert.match(app.run('getVenvPython()'), /venv-py310/);
+  });
+
+  test(`${file}: creates venv and installs using unsplit paths`, async () => {
+    const app = load(file, { versions: { python3: 'Python 3.12.0' }, missingDeps: true });
+    app.fakeFs.existsSync = filename => !filename.includes('/venv/');
+    await app.run('main()');
+    const create = app.calls.find(call => call.args[1] === 'venv');
+    const install = app.calls.find(call => call.args[1] === 'pip');
+    assert(create);
+    assert(install);
+    assert.match(create.args[2], /Jane Doe & Co/);
+    assert.match(install.args[4], /Jane Doe & Co/);
+    assert(app.calls.every(call => call.options.shell === false));
+    if (file.startsWith('bin')) {
+      assert.equal(JSON.stringify(create.options.stdio), '["ignore",2,2]');
+      assert.equal(JSON.stringify(install.options.stdio), '["ignore",2,2]');
+      const server = app.calls.find(call => call.args[0].endsWith('mcp_server.py'));
+      assert.equal(server.options.stdio, 'inherit');
+    }
+  });
+}


### PR DESCRIPTION
Queries and downloads can currently hide failures, overwrite distinct reports, and return misleading results. This change preserves partial query results and per-file download outcomes, validates stock codes before side effects, and saves validated PDFs atomically under attachment-specific filenames.

- Propagate connectivity probe failures through `tee` so outage notifications run.
- Keep Python setup output off MCP stdout, validate interpreter versions, reuse compatible environments, and spawn Python directly for paths containing spaces or shell characters.
- Exclude supporting documents from prospectus results and interpret announcement timestamps in China Standard Time.
- Resolve attachment URLs consistently and validate the HTTPS host and port before every request and redirect.

Responses now expose `status: complete | partial | error`; `success` is true only for complete operations, including successful empty queries. Python callers receive `QueryError` with retained reports when a query is incomplete. Download responses include successful files and individual failures. The README documents these behavior changes and the development test command.

Validation: 103 Python tests and 8 launcher tests passed. MCP initialization, tool/resource discovery, and the packaging check also passed. Windows spawning is covered by mocks; native Windows execution and live CNINFO downloads were not exercised.
